### PR TITLE
disables autoload of R/

### DIFF
--- a/R/_disable_autoload.R
+++ b/R/_disable_autoload.R
@@ -1,0 +1,3 @@
+# see shiny::loadSupport for details on this file
+# this file is used to disable autoloading of R files in the R/ directory
+# instead, should be loaded with pkgload::load_all(".")


### PR DESCRIPTION
disables shiny trying to load R/, which we load via pkgload::load_all instead