### PR TITLE
slight refactor of tests

### DIFF
--- a/R/ZZZ.R
+++ b/R/ZZZ.R
@@ -2,3 +2,10 @@
 NULL
 
 utils::globalVariables("temp")
+
+# in order to mock these base functions in tests, we need to declare them
+# see https://testthat.r-lib.org/articles/mocking.html
+# nolint start
+system.file <- NULL
+file.exists <- NULL
+# nolint end

--- a/tests/testthat/test-add_external_resources.R
+++ b/tests/testthat/test-add_external_resources.R
@@ -1,7 +1,7 @@
 test_that("app_sys", {
   # arrange
   m <- mock("path/to/file")
-  stub(app_sys, "system.file", m)
+  local_mocked_bindings(system.file = m)
 
   # act
   actual <- app_sys("subdir", "file.txt")

--- a/tests/testthat/test-app_server.R
+++ b/tests/testthat/test-app_server.R
@@ -123,7 +123,7 @@ test_that("sidebar accordion opens", {
   mocks <- setup_app_server_tests()
 
   m <- mock()
-  mockery::stub(app_server, "bslib::accordion_panel_open", m)
+  local_mocked_bindings(accordion_panel_open = m, .package = "bslib")
   # act
 
   shiny::testServer(

--- a/tests/testthat/test-fct_plots.R
+++ b/tests/testthat/test-fct_plots.R
@@ -37,7 +37,7 @@ test_that("plot_rates_trend", {
 
 test_that("plot_rates_funnel", {
   # arrange
-  set.seed(1)
+  withr::local_seed(1)
   # nolint start
   rates_funnel_data <- tibble::tribble(
     ~rate , ~denominator , ~national_rate , ~is_peer , ~provider ,

--- a/tests/testthat/test-fct_table.R
+++ b/tests/testthat/test-fct_table.R
@@ -1,6 +1,6 @@
 test_that("entable_encounters (diagnoses)", {
   # arrange
-  set.seed(1)
+  withr::local_seed(1)
   df <- tibble::tribble(
     ~diagnosis_description, ~n, ~pcnt,
     "A", 100, 0.5,
@@ -18,7 +18,7 @@ test_that("entable_encounters (diagnoses)", {
 
 test_that("entable_encounters (procedures)", {
   # arrange
-  set.seed(1)
+  withr::local_seed(1)
   df <- tibble::tribble(
     ~procedures_description, ~n, ~pcnt,
     "A", 100, 0.5,

--- a/tests/testthat/test-utils_data.R
+++ b/tests/testthat/test-utils_data.R
@@ -99,10 +99,9 @@ test_that("md_file_to_html returns NULL if file doesn't exist", {
 test_that("md_file_to_html reads valid file", {
   # arrange
   local_mocked_bindings(
-    "app_sys" = \(...) file.path(...)
+    "app_sys" = \(...) file.path(...),
+    "file.exists" = \(...) TRUE
   )
-
-  stub(md_file_to_html, "file.exists", TRUE)
 
   m1 <- mock("content")
   m2 <- mock("html")

--- a/tests/testthat/test-utils_server.R
+++ b/tests/testthat/test-utils_server.R
@@ -5,10 +5,16 @@ test_that("get_container uses get_azure_token when not in a managed environment"
   m_blob_endpoint <- mock("ep")
   m_storage_container <- mock("container")
 
-  stub(get_container, "AzureAuth::get_managed_token", m_get_managed_token)
-  stub(get_container, "AzureAuth::get_azure_token", m_get_azure_token)
-  stub(get_container, "AzureStor::blob_endpoint", m_blob_endpoint)
-  stub(get_container, "AzureStor::storage_container", m_storage_container)
+  local_mocked_bindings(
+    "get_managed_token" = m_get_managed_token,
+    "get_azure_token" = m_get_azure_token,
+    .package = "AzureAuth"
+  )
+  local_mocked_bindings(
+    "blob_endpoint" = m_blob_endpoint,
+    "storage_container" = m_storage_container,
+    .package = "AzureStor"
+  )
 
   # act
   actual <- get_container("ep_uri", "container_name")
@@ -40,10 +46,16 @@ test_that("get_container uses get_managed_token when in a managed environment", 
   m_blob_endpoint <- mock("ep")
   m_storage_container <- mock("container")
 
-  stub(get_container, "AzureAuth::get_managed_token", m_get_managed_token)
-  stub(get_container, "AzureAuth::get_azure_token", m_get_azure_token)
-  stub(get_container, "AzureStor::blob_endpoint", m_blob_endpoint)
-  stub(get_container, "AzureStor::storage_container", m_storage_container)
+  local_mocked_bindings(
+    "get_managed_token" = m_get_managed_token,
+    "get_azure_token" = m_get_azure_token,
+    .package = "AzureAuth"
+  )
+  local_mocked_bindings(
+    "blob_endpoint" = m_blob_endpoint,
+    "storage_container" = m_storage_container,
+    .package = "AzureStor"
+  )
 
   # act
   actual <- get_container("ep_uri", "container_name")


### PR DESCRIPTION
- eliminates any stub calls, favouring local_mocked_bindings
- uses withr::local_seed rather than set.seed
- adds bindings to some base functions so we can mock these in tests
