### PR TITLE
Replace jsonlite with yyjsonr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
     glue,
     gt,
     httr2,
-    jsonlite,
     markdown,
     purrr,
     readr,
@@ -38,8 +37,10 @@ Imports:
     shinycssloaders,
     stringr,
     tibble,
-    tidyr
+    tidyr,
+    yyjsonr
 Suggests:
+    jsonlite,
     mockery,
     testthat (>= 3.0.0),
     tidyselect,

--- a/R/mod_plot_rates.R
+++ b/R/mod_plot_rates.R
@@ -63,10 +63,9 @@ mod_plot_rates_server <- function(
       )
 
       shiny::req(filename)
-      providers_lookup <- jsonlite::read_json(
-        app_sys("app", "data", filename),
-        simplify_vector = TRUE
-      ) |>
+
+      providers_lookup <- app_sys("app", "data", filename) |>
+        yyjsonr::read_json_file() |>
         tibble::enframe("provider", "provider_label") |> # label for plotting
         tidyr::unnest(.data$provider_label)
 

--- a/R/mod_select_provider.R
+++ b/R/mod_select_provider.R
@@ -32,10 +32,7 @@ mod_select_provider_server <- function(id, selected_geography) {
 
       shiny::req(filename)
 
-      jsonlite::read_json(
-        app_sys("app", "data", filename),
-        simplify_vector = TRUE
-      )
+      yyjsonr::read_json_file(app_sys("app", "data", filename))
     }) |>
       shiny::bindEvent(selected_geography())
 

--- a/R/mod_select_strategy.R
+++ b/R/mod_select_strategy.R
@@ -40,10 +40,8 @@ mod_select_strategy_ui <- function(id) {
 #' @return A named list of data frames, where the names are the categories (IP/OP/AE)
 #' @noRd
 mod_select_strategy_get_strategies <- function() {
-  strategies <- jsonlite::read_json(
-    app_sys("app", "data", "mitigators.json"),
-    simplify_vector = TRUE
-  )
+  strategies <- app_sys("app", "data", "mitigators.json") |>
+    yyjsonr::read_json_file()
 
   strategies |>
     unlist() |>

--- a/R/mod_show_strategy_text.R
+++ b/R/mod_show_strategy_text.R
@@ -17,10 +17,7 @@ mod_show_strategy_text_ui <- function(id) {
 #' @return a character vector of the strategy stubs.
 #' @noRd
 mod_show_strategy_text_get_descriptions_lookup <- function() {
-  jsonlite::read_json(
-    app_sys("app", "data", "descriptions.json"),
-    simplifyVector = TRUE
-  )
+  yyjsonr::read_json_file(app_sys("app", "data", "descriptions.json"))
 }
 
 #' Show Strategy Description Server


### PR DESCRIPTION
May help with #110.

* Replace jsonlite calls with yyjsonr, as we did recently in [nhp_outputs](https://github.com/The-Strategy-Unit/nhp_outputs/pull/363), for example.

Aside, Tom: you may notice your your tests are mauled. This is because I've made so many changes so quickly ahead of the NNHIP meeting today. Not ideal, but I've [got an issue](https://github.com/The-Strategy-Unit/tpma-explorer/issues/104) to repair them.