### PR TITLE
Bump v0.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tpma.explorer
 Title: Explore Opportunities to Reduce Hospital Care
-Version: 0.4.0.9000
+Version: 0.5.0
 Authors@R: c(
     person("Matt", "Dray", , "matt.dray@nhs.net", role = c("aut", "cre")),
     person("Tom", "Jemmett", , "thomas.jemmett@nhs.net", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ In `R/` you can find:
 In `inst/` you can find:
 
 * `golem-config.yaml`, which contains configuration (copied from [nhp_inputs](https://github.com/The-Strategy-Unit/nhp_inputs/blob/main/inst/golem-config.yml))
-* lookup data files in `app/data/`
+* lookup data files in `app/reference/`
 * Markdown files under `app/text/`, which contain body and tooltip text

--- a/tests/testthat/_snaps/app_ui.md
+++ b/tests/testthat/_snaps/app_ui.md
@@ -162,7 +162,7 @@
                                 <p>This app was built and is maintained by <a href="https://www.strategyunitwm.nhs.uk/">The Strategy Unit</a>.
       The source code can be found in <a href="https://github.com/The-Strategy-Unit/tpma-explorer/">the open tpma-explorer GitHub repository</a>.</p>
       
-                                Version 0.4.0.9000.
+                                Version 0.5.0.
                               </div>
                               <script data-bslib-card-init>bslib.Card.initializeAllCards();</script>
                             </div>


### PR DESCRIPTION
* Adjust path to reference data in README.
* Bump version to v0.5.0.
* Accept new UI test snapshot (becuase the version number is printed in the app UI).