### PR TITLE
Tweak sidebar and tooltip UI

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -2,7 +2,7 @@
 #' @param input,output,session Internal parameters for 'shiny'.
 #' @noRd
 app_server <- function(input, output, session) {
-  # Constants
+  # Constants ----
   # nolint start: object_name_linter.
   BASE_SIZE <- 16 # scaling for plot elements
   # nolint end
@@ -22,8 +22,20 @@ app_server <- function(input, output, session) {
     as.numeric(Sys.getenv("BASELINE_YEAR", 202324))
   })
 
-  # Open UI accordion ----
+  # Open sidebar ---
   shiny::observe({
+    if (input$page_navbar == "Visualisations") {
+      # Sidebar options only relevant to visualisations
+      bslib::toggle_sidebar("sidebar", open = TRUE)
+    } else {
+      bslib::toggle_sidebar("sidebar", open = FALSE)
+    }
+  }) |>
+    shiny::bindEvent(input$page_navbar)
+
+  # Open sidebar accordions ----
+  shiny::observe({
+    # Data must load before accordions open
     shiny::req(selected_provider())
     shiny::req(selected_strategy())
     bslib::accordion_panel_open(id = "sidebar_accordion", values = TRUE)

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -9,6 +9,8 @@ app_ui <- function(request) {
     fillable = FALSE, # allow page scroll
 
     sidebar = bslib::sidebar(
+      id = "sidebar",
+      open = "closed",
       width = 400,
       bslib::accordion(
         id = "sidebar_accordion",

--- a/inst/app/text/viz-tooltip-box.md
+++ b/inst/app/text/viz-tooltip-box.md
@@ -1,5 +1,5 @@
-Distribution of rates for all units, highlighting the selected unit (red) and peers.
+Distribution of rates for all units, showing only the selected unit (red) and peers (grey).
 The box identifies the limits of the central half of the data.
-The line inside is the median value.
+The horizontal line inside is the median value.
 Points beyond the ends of the vertical lines are considered outliers.
 Data is age-sex standardised.

--- a/inst/app/text/viz-tooltip-funnel.md
+++ b/inst/app/text/viz-tooltip-funnel.md
@@ -1,4 +1,4 @@
-Baseline activity for all units, highlighting the selected unit (red) and peers (dark grey).
+Baseline activity for all units (grey), highlighting the selected unit (red) and peers (black outline).
 The horizontal dashed line is the mean of all units.
 The inner dashed funnel is two standard deviations from the mean, the outer is three.
 Points outside of the outer funnel are considered outliers.

--- a/inst/app/text/viz-tooltip-trend.md
+++ b/inst/app/text/viz-tooltip-trend.md
@@ -1,2 +1,2 @@
-How activity for the selected TPMA has changed over time for the chosen unit (red) and peers.
+How activity for the selected TPMA has changed over time for the chosen unit (red) and peers (grey).
 Data is age-sex standardised. Years of availability will depend on the selected unit and TPMA.

--- a/tests/testthat/_snaps/app_ui.md
+++ b/tests/testthat/_snaps/app_ui.md
@@ -41,7 +41,7 @@
           </div>
         </nav>
         <div class="html-fill-item html-fill-container">
-          <div class="bslib-sidebar-layout bslib-mb-spacing html-fill-item" data-bslib-sidebar-border="false" data-bslib-sidebar-border-radius="false" data-bslib-sidebar-init="TRUE" data-collapsible-desktop="true" data-collapsible-mobile="false" data-open-desktop="open" data-open-mobile="always" data-require-bs-caller="layout_sidebar()" data-require-bs-version="5" style="--_sidebar-width:400px;">
+          <div class="bslib-sidebar-layout bslib-mb-spacing sidebar-collapsed html-fill-item" data-bslib-sidebar-border="false" data-bslib-sidebar-border-radius="false" data-bslib-sidebar-init="TRUE" data-collapsible-desktop="true" data-collapsible-mobile="true" data-open-desktop="closed" data-open-mobile="closed" data-require-bs-caller="layout_sidebar()" data-require-bs-version="5" style="--_sidebar-width:400px;">
             <div class="main">
               <main class="bslib-page-main bslib-gap-spacing">
                 <div class="tab-content" data-tabsetid="X">
@@ -174,7 +174,7 @@
                 </div>
               </main>
             </div>
-            <aside id="bslib-sidebar-X" class="sidebar" hidden>
+            <aside id="sidebar" class="sidebar bslib-sidebar-input" hidden>
               <div class="sidebar-content bslib-gap-spacing">
                 <div class="accordion bslib-accordion-input" data-require-bs-caller="accordion()" data-require-bs-version="5" id="sidebar_accordion">
                   <div class="accordion-item" data-value="Datasets">
@@ -219,7 +219,7 @@
                 </div>
               </div>
             </aside>
-            <button class="collapse-toggle" type="button" title="Toggle sidebar" aria-expanded="true" aria-controls="bslib-sidebar-X"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-chevron-left collapse-icon" style="height:;width:;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img" ><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"></path></svg></button>
+            <button class="collapse-toggle" type="button" title="Toggle sidebar" aria-expanded="false" aria-controls="sidebar"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-chevron-left collapse-icon" style="height:;width:;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img" ><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"></path></svg></button>
             <script data-bslib-sidebar-init>bslib.Sidebar.initCollapsibleAll()</script>
           </div>
         </div>

--- a/tests/testthat/_snaps/mod_plot_rates_box.md
+++ b/tests/testthat/_snaps/mod_plot_rates_box.md
@@ -8,9 +8,9 @@
           <div class="card-header bslib-gap-spacing">
             Rates Box
             <bslib-tooltip placement="right" bsOptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
-              <template><p>Distribution of rates for all units, highlighting the selected unit (red) and peers.
+              <template><p>Distribution of rates for all units, showing only the selected unit (red) and peers (grey).
       The box identifies the limits of the central half of the data.
-      The line inside is the median value.
+      The horizontal line inside is the median value.
       Points beyond the ends of the vertical lines are considered outliers.
       Data is age-sex standardised.</p>
       </template>

--- a/tests/testthat/_snaps/mod_plot_rates_funnel.md
+++ b/tests/testthat/_snaps/mod_plot_rates_funnel.md
@@ -8,7 +8,7 @@
           <div class="card-header bslib-gap-spacing">
             Rates Funnel
             <bslib-tooltip placement="right" bsOptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
-              <template><p>Baseline activity for all units, highlighting the selected unit (red) and peers (dark grey).
+              <template><p>Baseline activity for all units (grey), highlighting the selected unit (red) and peers (black outline).
       The horizontal dashed line is the mean of all units.
       The inner dashed funnel is two standard deviations from the mean, the outer is three.
       Points outside of the outer funnel are considered outliers.

--- a/tests/testthat/_snaps/mod_plot_rates_trend.md
+++ b/tests/testthat/_snaps/mod_plot_rates_trend.md
@@ -8,7 +8,7 @@
           <div class="card-header bslib-gap-spacing">
             Rates Trend
             <bslib-tooltip placement="right" bsOptions="[]" data-require-bs-version="5" data-require-bs-caller="tooltip()">
-              <template><p>How activity for the selected TPMA has changed over time for the chosen unit (red) and peers.
+              <template><p>How activity for the selected TPMA has changed over time for the chosen unit (red) and peers (grey).
       Data is age-sex standardised. Years of availability will depend on the selected unit and TPMA.</p>
       </template>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-info-circle " style="height:1em;width:1em;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img" ><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path>

--- a/tests/testthat/test-app_server.R
+++ b/tests/testthat/test-app_server.R
@@ -104,6 +104,46 @@ test_that("sidebar accordion opens", {
   )
 })
 
+test_that("sidebar opens when Visualisations tab is selected", {
+  # arrange
+  mocks <- setup_app_server_tests()
+  m <- mock()
+  local_mocked_bindings(toggle_sidebar = m, .package = "bslib")
+
+  shiny::testServer(
+    app_server,
+    {
+      # act
+      session$setInputs(page_navbar = "Visualisations")
+      session$flushReact()
+
+      # assert
+      expect_called(m, 1)
+      expect_args(m, 1, "sidebar", open = TRUE)
+    }
+  )
+})
+
+test_that("sidebar closes when a non-Visualisations tab is selected", {
+  # arrange
+  mocks <- setup_app_server_tests()
+  m <- mock()
+  local_mocked_bindings(toggle_sidebar = m, .package = "bslib")
+
+  shiny::testServer(
+    app_server,
+    {
+      # act
+      session$setInputs(page_navbar = "Information")
+      session$flushReact()
+
+      # assert
+      expect_called(m, 1)
+      expect_args(m, 1, "sidebar", open = FALSE)
+    }
+  )
+})
+
 test_that("mod_show_strategy_text_server", {
   # arrange
   mocks <- setup_app_server_tests()


### PR DESCRIPTION
Close #158.

* Sidebar closes when the Information page is selected (it's only needed on the Visualisations page). Bonus: the sidebar opens on app load, visually hinting to the user that it can be opened/closed.
* Corrected typo in one rate tooltip, tweaked other tooltip text.
* Added test coverage for auto-opening/closing sidebar, updated snapshots.