### PR TITLE
Tweak azkit function input to allow data downloads

### DIFF
--- a/R/utils_server.R
+++ b/R/utils_server.R
@@ -93,8 +93,7 @@ download_geo_data <- function(geography_folder, data_version = Sys.getenv("DATA_
 
   azkit::read_azure_parquet(
     inputs_container,
-    data_type,
-    container_dir
+    glue::glue("{container_dir}/{data_type}.parquet")
   ) |>
     dplyr::rename(dplyr::any_of(col_renames)) |>
     tidyr::drop_na("strategy") |>

--- a/tests/testthat/test-utils_server.R
+++ b/tests/testthat/test-utils_server.R
@@ -221,8 +221,7 @@ test_that("_download_geo_data_file works", {
     m_read_azure_parquet,
     1,
     "container",
-    "data",
-    "dev/nhp"
+    "dev/nhp/data.parquet"
   )
   expect_called(m_write_parquet, 1)
   expect_args(


### PR DESCRIPTION
* Simplified input to `azkit::read_azure_parquet()`, given {azkit} v0.2.6.
* Corrected associated test.
* Already deployed to dev.

Walked through with @tomjemmett. Was preventing data from being downloaded, causing a subsequent error when the app tried to read it.