### PR TITLE
Simplify `.Renviron.example`

### DIFF
--- a/.Renviron.example
+++ b/.Renviron.example
@@ -1,10 +1,5 @@
-# To run app locally and in deployment
 AZ_CONTAINER_INPUTS=
 AZ_STORAGE_EP=
-AZ_SUPPORT_CONTAINER=
 BASELINE_YEAR=
 DATA_VERSION=
 FEEDBACK_FORM_URL=
-# To run app locally
-AZ_APP_ID=
-AZ_TENANT_ID=


### PR DESCRIPTION
After chatting in coworking session today, remove:

* `AZ_APP_ID` and `AZ_TENANT_ID` (not necessary)
* `AZ_SUPPORT_CONTAINER` (no longer needed)