### PR TITLE
Reset the cache via URL query param

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -82,16 +82,18 @@ app_server <- function(input, output, session) {
   )
 
   # Reset cache with query param ?reset_cache=true
+  # nocov start
   shiny::observe({
     shiny::req("su-data-science" %in% session$groups)
 
     u <- shiny::parseQueryString(session$clientData$url_search)
 
-    shiny::req(!is.null(u$reset_cache)) # value doesn't matter
+    shiny::req(!is.null(u$reset_cache)) # i.e. param value doesn't matter
     cat("reset cache\n")
 
     dc <- shiny::shinyOptions()$cache
 
     dc$reset()
   })
+  # nocov end
 }

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -80,4 +80,18 @@ app_server <- function(input, output, session) {
     "mod_plot_nee",
     selected_strategy
   )
+
+  # Reset cache with query param ?reset_cache=true
+  shiny::observe({
+    shiny::req("su-data-science" %in% session$groups)
+
+    u <- shiny::parseQueryString(session$clientData$url_search)
+
+    shiny::req(!is.null(u$reset_cache)) # value doesn't matter
+    cat("reset cache\n")
+
+    dc <- shiny::shinyOptions()$cache
+
+    dc$reset()
+  })
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Note that the data are downloaded to the `app_data/` folder when you `run_app()`
 
 Locally, you can force-redownload the data by (a) deleting `app_data/` and re-sourcing `app.R`, or (b) by running  `get_all_data()` with the argument `redownload = TRUE`.
 
-On the server, you can invalidate the current cache by appending `?reset_cache=true` to the app's URL (authorised devs only).
+On the server, authorised devs can invalidate the current cache by appending `?reset_cache=true` to the apps' canonical URLs (i.e. `https://connect.strategyunitwm.nhs.uk/tpma-explorer` and `/tpma-explorer-dev`).
 The data will be re-fetched the next time the app starts up.
 
 ### Files

--- a/README.md
+++ b/README.md
@@ -42,14 +42,16 @@ The data will be re-fetched the next time the app starts up.
 
 ### Files
 
-In `R/` you can find:
+In:
 
-* Shiny modules (server and UI components) that are stored in `mod_*.R` scripts
-* functions to help prepare data in `utils_*.R` scripts
-* logic for user facing outputs (plots, tables) in `fct_*.R` scripts
-
-In `inst/` you can find:
-
-* `golem-config.yaml`, which contains configuration (copied from [nhp_inputs](https://github.com/The-Strategy-Unit/nhp_inputs/blob/main/inst/golem-config.yml))
-* lookup data files in `app/reference/`
-* Markdown files under `app/text/`, which contain body and tooltip text
+* `app_data/` you can find data downloaded from Azure (if `run_app()` has been run at least once)
+* `data-raw/` you can can find code used to generate lookups in `inst/app/reference/`
+* `dev/` you can find the `deploy.R` script to deploy to Posit Connect
+* `inst/` you can find:
+    * `golem-config.yaml`, which contains configuration (copied from [nhp_inputs](https://github.com/The-Strategy-Unit/nhp_inputs/blob/main/inst/golem-config.yml))
+    * lookup data files in `app/reference/`
+    * Markdown files under `app/text/`, which contain body and tooltip text
+* `R/` you can find:
+    * Shiny modules (server and UI components) that are stored in `mod_*.R` scripts
+    * functions to help prepare data in `utils_*.R` scripts
+    * logic for user facing outputs (plots, tables) in `fct_*.R` scripts

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To run the app, you must:
 
 Underlying data is generated via the NHP inputs-data pipeline in [the nhp_data repository](https://github.com/The-Strategy-Unit/nhp_data/) and is read into the app from the relevant Azure container (named in the `AZ_CONTAINER_INPUTS` environment variable).
 
+If the data updates and you need to invalidate the current cache, you can append `?reset_cache=true` to the app's URL to force a reset (authorised devs only).
+
 ### Files
 
 In `R/` you can find:

--- a/README.md
+++ b/README.md
@@ -27,9 +27,18 @@ To run the app, you must:
 
 ### Data
 
+#### Location
+
 Underlying data is generated via the NHP inputs-data pipeline in [the nhp_data repository](https://github.com/The-Strategy-Unit/nhp_data/) and is read into the app from the relevant Azure container (named in the `AZ_CONTAINER_INPUTS` environment variable).
 
-If the data updates and you need to invalidate the current cache, you can append `?reset_cache=true` to the app's URL to force a reset (authorised devs only).
+#### Invalidation
+
+Note that the data are downloaded to the `app_data/` folder when you `run_app()`.
+
+Locally, you can force-redownload the data by (a) deleting `app_data/` and re-sourcing `app.R`, or (b) by running  `get_all_data()` with the argument `redownload = TRUE`.
+
+On the server, you can invalidate the current cache by appending `?reset_cache=true` to the app's URL (authorised devs only).
+The data will be re-fetched the next time the app starts up.
 
 ### Files
 

--- a/tests/testthat/_snaps/app_ui.md
+++ b/tests/testthat/_snaps/app_ui.md
@@ -309,7 +309,7 @@
                 </div>
               </main>
             </div>
-            <aside id="sidebar" class="sidebar bslib-sidebar-input" hidden>
+            <aside id="sidebar" class="sidebar bslib-sidebar-input" hidden data-resizable>
               <div class="sidebar-content bslib-gap-spacing">
                 <div class="accordion bslib-accordion-input" data-require-bs-caller="accordion()" data-require-bs-version="5" id="sidebar_accordion">
                   <div class="accordion-item" data-value="Datasets">


### PR DESCRIPTION
Allows #185.

* Added cache invalidation observer, lifted from nhp_inputs.
* Adjusted the group check to `su-data-science` rather than `nhp_devs`.
* Updated README to explain the process.

